### PR TITLE
Unwrap getCurrentTime as a Double. Float was returning nil.

### DIFF
--- a/Sources/YoutubePlayerView/YoutubePlayerView.swift
+++ b/Sources/YoutubePlayerView/YoutubePlayerView.swift
@@ -561,9 +561,9 @@ extension YoutubePlayerView {
     /// method corresponds to the JavaScript API defined here:
     ///   `https://developers.google.com/youtube/iframe_api_reference#getCurrentTime`
     ///
-    public func fetchCurrentTime(_ completionHandler: @escaping (Float?) -> ()) {
+    public func fetchCurrentTime(_ completionHandler: @escaping (Double?) -> ()) {
         webView.evaluateJavaScript("player.getCurrentTime();") { (data, _) in
-            completionHandler(data as? Float)
+            completionHandler(data as? Double)
         }
     }
 }


### PR DESCRIPTION
`getCurrentTime` was returning `nil`. Unwrapping as a Double solves this issue.